### PR TITLE
automate adding postgis extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timescale/timescaledb:latest-pg16
+FROM timescale/timescaledb:2.15.2-pg16
 # adapted from https://github.com/timescale/timescaledb-docker/blob/d31d31a66626e9dc491a440aa1b74c0c37e2aa54/postgis/Dockerfile
 ENV POSTGIS_VERSION 3.4.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,5 @@ RUN set -ex \
     && cd / \
     && rm -rf /tmp/postgis-${POSTGIS_VERSION} \
     && apk del .fetch-deps .build-deps .build-deps-edge
+
+COPY docker-entrypoint-initdb.d/002_add_postgis.sh /docker-entrypoint-initdb.d/002_add_postgis.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ the timescaledb-postgis image is [discontinued](https://github.com/timescale/tim
 
 the [timescale/timescaledb-ha](https://hub.docker.com/r/timescale/timescaledb-ha/tags) docker image includes postgis but has a size of **1.5gb**
 
-the size of this [mxfactorial/timescaledb-postgis:latest](https://hub.docker.com/r/mxfactorial/timescaledb-postgis) image is approximately **221mb**
+the size of this [mxfactorial/timescaledb-postgis:latest](https://hub.docker.com/r/mxfactorial/timescaledb-postgis) image is approximately **268mb**
 
 development only
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ make
 ```sh
 # 1. start the container
 docker run -d -it -p 5432:5432 --name timescaledb-postgis -e POSTGRES_PASSWORD=password mxfactorial/timescaledb-postgis:latest
-# 2. install the postgis extension
-docker exec -e PGPASSWORD=password timescaledb-postgis psql -h localhost -U postgres -c "CREATE EXTENSION postgis;"
-# 3. print currently installed extensions
+# 2. print currently installed extensions
 docker exec -e PGPASSWORD=password timescaledb-postgis psql -h localhost -U postgres -c "\dx;"
-# 4. connect using your preferred client
+# 3. connect using your preferred client
 ```
 
 #### clean up

--- a/docker-entrypoint-initdb.d/002_add_postgis.sh
+++ b/docker-entrypoint-initdb.d/002_add_postgis.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+psql -U postgres -c "CREATE EXTENSION postgis;"

--- a/docker-entrypoint-initdb.d/README.md
+++ b/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,1 @@
+numbered prefix start after upstream init files: https://github.com/timescale/timescaledb-docker/tree/main/docker-entrypoint-initdb.d


### PR DESCRIPTION
removes `CREATE EXTENSION postgis;` step

also, a bug introduced in the upstream timescaledb-docker repo required pinning to the timescale 2.15.2 base image

will use new timescale versions after https://github.com/timescale/timescaledb-docker/pull/267 merge